### PR TITLE
스택메모리에 잡은건 반환하는 함수 내용을 수정. vector를 new로 생성해서 포인터 채로 반환하도록 구성

### DIFF
--- a/Acquitaine Engine/Acquitaine Game Engine/ParentComponent.cpp
+++ b/Acquitaine Engine/Acquitaine Game Engine/ParentComponent.cpp
@@ -31,6 +31,11 @@ namespace act
 		return *_gameObject;
 	}
 
+	std::string ParentComponent::GetComonentName()
+	{
+		return _componentName;
+	}
+
 	void ParentComponent::Initialize()
 	{
 	}

--- a/Acquitaine Engine/Acquitaine Game Engine/ParentComponent.h
+++ b/Acquitaine Engine/Acquitaine Game Engine/ParentComponent.h
@@ -31,6 +31,7 @@ namespace act
 
 		virtual void SetGameObject(ParentObject* parentObject);
 		virtual ParentObject& GetGameObject();
+		std::string GetComonentName();
 
 	protected:
 		std::string _componentName;		// 컴포넌트의 이름

--- a/Acquitaine Engine/Acquitaine Game Engine/ParentObject.h
+++ b/Acquitaine Engine/Acquitaine Game Engine/ParentObject.h
@@ -24,15 +24,14 @@ namespace act
 			_includedScene->AddObject<T>(objectName);
 		}
 
-		template<typename T>
-		void AddComponent(std::string componentname, ParentObject* thispointer)
+		template<typename T> ParentComponent* AddComponent(std::string componentname, ParentObject* thispointer)
 		{
 			ParentComponent* temp = new T(componentname, thispointer);
 			_componentList.push_back(temp);
 		}
 
 		template<typename T>
-		T* GetComponentPointer()
+		ParentComponent* GetComponentPointer()
 		{
 			for (auto pComponent : _componentList)
 			{
@@ -46,11 +45,11 @@ namespace act
 		}
 
 		template<typename T>
-		T* GetComponentPointer(std::string componentName)
+		ParentComponent* GetComponentPointer(std::string componentName)
 		{
 			for (auto pComponent : _componentList)
 			{
-				if (pComponent->_componentName == componentName)
+				if (pComponent->GetComonentName() == componentName)
 				{
 					return pComponent;
 				}
@@ -59,18 +58,18 @@ namespace act
 		}
 
 		template<typename T>
-		std::vector<T*>* GetComponentPointers()
+		std::vector<ParentComponent*>* GetComponentPointers()
 		{
-			std::vector<T*> temp;
+			std::vector<ParentComponent*>* temp = new std::vector<ParentComponent*>;
 			for (auto pComponent : _componentList)
 			{
 				T* childComponent = dynamic_cast<T*>(pComponent);
 				if (childComponent != nullptr)
 				{
-					temp.push_back(childComponent);
+					temp->push_back(childComponent);
 				}
 			}
-			return &temp;
+			return temp;
 		}
 
 		std::vector<ParentComponent*>& GetComponentlist();


### PR DESCRIPTION
name을 비교하는 함수의 경우 내부의 name을 getter로 받아오도록 변경
addcomponent를 할때 생성한 컴포넌트의 포인터를 반환하도록 설정.